### PR TITLE
Revert "Bump discord-api-types from 0.26.1 to 0.31.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "cors": "^2.8.5",
     "cpu-stat": "^2.0.1",
     "custom-env": "^2.0.1",
-    "discord-api-types": "^0.31.0",
+    "discord-api-types": "^0.26.1",
     "discord.js": "^13.5.0",
     "dotenv-flow": "^3.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
Reverts Tetracyl/EarTensifier#119